### PR TITLE
Prevent low layer unwrap

### DIFF
--- a/src/main/java/tudelft/ti2806/pl3/data/wrapper/CombineWrapper.java
+++ b/src/main/java/tudelft/ti2806/pl3/data/wrapper/CombineWrapper.java
@@ -60,8 +60,9 @@ public abstract class CombineWrapper extends Wrapper {
 		}
 		return str.toString() + "}";
 	}
-
-	@Override public int getId() {
+	
+	@Override
+	public int getId() {
 		return nodeList.get(0).getId();
 	}
 	

--- a/src/main/java/tudelft/ti2806/pl3/data/wrapper/CombineWrapper.java
+++ b/src/main/java/tudelft/ti2806/pl3/data/wrapper/CombineWrapper.java
@@ -79,4 +79,8 @@ public abstract class CombineWrapper extends Wrapper {
 		}
 		this.x /= this.getNodeList().size();
 	}
+	
+	public boolean canUnwrap() {
+		return true;
+	}
 }

--- a/src/main/java/tudelft/ti2806/pl3/data/wrapper/HorizontalWrapper.java
+++ b/src/main/java/tudelft/ti2806/pl3/data/wrapper/HorizontalWrapper.java
@@ -15,14 +15,21 @@ import java.util.Set;
  */
 public class HorizontalWrapper extends CombineWrapper {
 	
+	private boolean canUnwrap = true;
+	
 	/**
 	 * An collection of {@link SNodes} which can be used as a single SNode.
 	 * 
 	 * @param nodePosList
 	 *            a connected and sorted list of edges.
 	 */
-	public HorizontalWrapper(List<Wrapper> nodePosList) {
+	public HorizontalWrapper(List<Wrapper> nodePosList, boolean canUnwrap) {
 		super(nodePosList);
+		this.canUnwrap = canUnwrap;
+	}
+	
+	public boolean canUnwrap() {
+		return canUnwrap;
 	}
 	
 	@Override

--- a/src/main/java/tudelft/ti2806/pl3/data/wrapper/HorizontalWrapper.java
+++ b/src/main/java/tudelft/ti2806/pl3/data/wrapper/HorizontalWrapper.java
@@ -28,6 +28,7 @@ public class HorizontalWrapper extends CombineWrapper {
 		this.canUnwrap = canUnwrap;
 	}
 	
+	@Override
 	public boolean canUnwrap() {
 		return canUnwrap;
 	}

--- a/src/main/java/tudelft/ti2806/pl3/data/wrapper/operation/collapse/CalculateCollapseOnSpace.java
+++ b/src/main/java/tudelft/ti2806/pl3/data/wrapper/operation/collapse/CalculateCollapseOnSpace.java
@@ -37,9 +37,11 @@ public class CalculateCollapseOnSpace extends WrapperOperation {
 	
 	@Override
 	public void calculate(HorizontalWrapper wrapper, Wrapper container) {
-		super.calculate(wrapper, container);
-		wrapper.addCollapse(getSpaceLeft(wrapper));
-		this.addToList(wrapper);
+		if (wrapper.canUnwrap()) {
+			super.calculate(wrapper, container);
+			wrapper.addCollapse(getSpaceLeft(wrapper));
+			this.addToList(wrapper);
+		}
 	}
 	
 	@Override
@@ -52,6 +54,7 @@ public class CalculateCollapseOnSpace extends WrapperOperation {
 	@Override
 	public void calculate(VerticalWrapper wrapper, Wrapper container) {
 		super.calculate(wrapper, container);
+		wrapper.addCollapse(getSpaceLeft(wrapper));
 		this.addToList(wrapper);
 	}
 	

--- a/src/main/java/tudelft/ti2806/pl3/data/wrapper/operation/unwrap/Unwrap.java
+++ b/src/main/java/tudelft/ti2806/pl3/data/wrapper/operation/unwrap/Unwrap.java
@@ -299,7 +299,8 @@ public abstract class Unwrap extends WrapperOperation {
 	 */
 	private Wrapper createNewNode(Wrapper node) {
 		if (node instanceof SingleWrapper || node instanceof CombineWrapper
-				&& isConditionMet((CombineWrapper) node)) {
+				&& isConditionMet((CombineWrapper) node)
+				&& ((CombineWrapper) node).canUnwrap()) {
 			WrapperPlaceholder placeholder = new WrapperPlaceholder();
 			stack.add(new Pair<>(placeholder, node));
 			return placeholder;

--- a/src/main/java/tudelft/ti2806/pl3/data/wrapper/operation/unwrap/Unwrap.java
+++ b/src/main/java/tudelft/ti2806/pl3/data/wrapper/operation/unwrap/Unwrap.java
@@ -298,9 +298,8 @@ public abstract class Unwrap extends WrapperOperation {
 	 *         either a {@link WrapperPlaceholder} or a {@link WrapperClone}.
 	 */
 	private Wrapper createNewNode(Wrapper node) {
-		if (node instanceof CombineWrapper
-				&& isConditionMet((CombineWrapper) node)
-				|| node instanceof SingleWrapper) {
+		if (node instanceof SingleWrapper || node instanceof CombineWrapper
+				&& isConditionMet((CombineWrapper) node)) {
 			WrapperPlaceholder placeholder = new WrapperPlaceholder();
 			stack.add(new Pair<>(placeholder, node));
 			return placeholder;

--- a/src/main/java/tudelft/ti2806/pl3/data/wrapper/util/HorizontalWrapUtil.java
+++ b/src/main/java/tudelft/ti2806/pl3/data/wrapper/util/HorizontalWrapUtil.java
@@ -22,7 +22,7 @@ import java.util.Map;
 public final class HorizontalWrapUtil {
 	private HorizontalWrapUtil() {
 	}
-
+	
 	/**
 	 * Constructs a {@link WrappedGraphData} instance which contains the
 	 * horizontal collapsed graph of the given graph.
@@ -33,8 +33,10 @@ public final class HorizontalWrapUtil {
 	 *         {@code null} if nothing could be collapsed
 	 */
 	@SuppressWarnings("CPD-START")
-	public static WrappedGraphData collapseGraph(WrappedGraphData original) {
-		List<Wrapper> newLayer = combineNodes(original.getPositionedNodes());
+	public static WrappedGraphData collapseGraph(WrappedGraphData original,
+			boolean canUnwrap) {
+		List<Wrapper> newLayer = combineNodes(original.getPositionedNodes(),
+				canUnwrap);
 		if (newLayer == null) {
 			return null;
 		}
@@ -42,17 +44,18 @@ public final class HorizontalWrapUtil {
 	}
 	
 	/**
-	 * Combines nodes vertically. Combines all {@link DataNode}s in the
-	 * given list of node into {@link VerticalWrapper}s, reconnects the
-	 * {@link VerticalWrapper}s in the graph and remove all
-	 * {@link DataNode}s which are combined from the graph.
+	 * Combines nodes vertically. Combines all {@link DataNode}s in the given
+	 * list of node into {@link VerticalWrapper}s, reconnects the
+	 * {@link VerticalWrapper}s in the graph and remove all {@link DataNode}s
+	 * which are combined from the graph.
 	 * 
 	 * @param nodes
 	 *            the nodes to combine
 	 * @return the collapsed version of the given graph<br>
 	 *         {@code null} if nothing could be collapsed
 	 */
-	static List<Wrapper> combineNodes(List<Wrapper> parentLayer) {
+	static List<Wrapper> combineNodes(List<Wrapper> parentLayer,
+			boolean canUnwrap) {
 		Map<String, Wrapper> nonWrappedNodes = new HashMap<>(parentLayer.size());
 		List<String> nonWrappedNodesOrder = new ArrayList<>(parentLayer.size());
 		for (Wrapper node : parentLayer) {
@@ -62,7 +65,7 @@ public final class HorizontalWrapUtil {
 		}
 		List<CombineWrapper> combinedNodes = new ArrayList<>();
 		for (List<Wrapper> list : findCombineableNodes(parentLayer)) {
-			HorizontalWrapper newNode = new HorizontalWrapper(list);
+			HorizontalWrapper newNode = new HorizontalWrapper(list, canUnwrap);
 			combinedNodes.add(newNode);
 			for (Wrapper wrapper : list) {
 				nonWrappedNodes.remove(wrapper.getIdString());
@@ -110,7 +113,7 @@ public final class HorizontalWrapUtil {
 				if (startNode == null) {
 					continue;
 				}
-
+				
 				List<Wrapper> foundGroup = new ArrayList<>();
 				foundGroup.add(startNode);
 				// Add all nodes to the right which can be combined.

--- a/src/main/java/tudelft/ti2806/pl3/data/wrapper/util/WrapUtil.java
+++ b/src/main/java/tudelft/ti2806/pl3/data/wrapper/util/WrapUtil.java
@@ -59,11 +59,15 @@ public final class WrapUtil {
 	 *         found, with only using vertical and horizontal options.
 	 */
 	public static WrappedGraphData collapseGraphSimple(WrappedGraphData original) {
-		WrappedGraphData graph = original;
 		WrappedGraphData lastGraph = original;
+		WrappedGraphData graph = HorizontalWrapUtil.collapseGraph(original,
+				false);
+		if (graph == null) {
+			graph = original;
+		}
 		while (graph != null) {
 			lastGraph = graph;
-			graph = HorizontalWrapUtil.collapseGraph(graph);
+			graph = HorizontalWrapUtil.collapseGraph(graph, true);
 			if (graph == null) {
 				graph = lastGraph;
 			} else {

--- a/src/test/java/tudelft/ti2806/pl3/data/wrapper/HorizontalWrapperTest.java
+++ b/src/test/java/tudelft/ti2806/pl3/data/wrapper/HorizontalWrapperTest.java
@@ -27,7 +27,7 @@ public class HorizontalWrapperTest {
 		wrapperList.add(wrapper1);
 		wrapperList.add(wrapper2);
 		wrapperList.add(wrapper3);
-		HorizontalWrapper wrapper = new HorizontalWrapper(wrapperList);
+		HorizontalWrapper wrapper = new HorizontalWrapper(wrapperList, true);
 		assertEquals(7, wrapper.getBasePairCount(), 0);
 		assertEquals(wrapper1.getGenome(), wrapper.getGenome());
 		assertEquals('H', wrapper.getIdString().charAt(0));
@@ -36,7 +36,7 @@ public class HorizontalWrapperTest {
 	
 	@Test
 	public void operationTest() {
-		operationTest(new HorizontalWrapper(null), null);
+		operationTest(new HorizontalWrapper(null, true), null);
 	}
 	
 	private void operationTest(HorizontalWrapper wrapper, Wrapper container) {

--- a/src/test/java/tudelft/ti2806/pl3/data/wrapper/operation/unwrap/HorizontalWrappedUnwrapTest.java
+++ b/src/test/java/tudelft/ti2806/pl3/data/wrapper/operation/unwrap/HorizontalWrappedUnwrapTest.java
@@ -154,7 +154,7 @@ public class HorizontalWrappedUnwrapTest {
 		list.add(wrapper2);
 		wrapper1.getOutgoing().add(wrapper2);
 		wrapper2.getIncoming().add(wrapper1);
-		return new HorizontalWrapper(list);
+		return new HorizontalWrapper(list, true);
 	}
 	
 	/**

--- a/src/test/java/tudelft/ti2806/pl3/data/wrapper/operation/unwrap/SingleWrapperUnwrapTest.java
+++ b/src/test/java/tudelft/ti2806/pl3/data/wrapper/operation/unwrap/SingleWrapperUnwrapTest.java
@@ -67,7 +67,7 @@ public class SingleWrapperUnwrapTest {
 		singleWrapper.getOutgoing().add(nodePosition3);
 		singleWrapper.getIncoming().add(nodePosition1);
 		nodePosition3.getIncoming().add(singleWrapper);
-		HorizontalWrapper start = new HorizontalWrapper(list);
+		HorizontalWrapper start = new HorizontalWrapper(list, true);
 		
 		unwrap = new UnwrapTest();
 		unwrap.compute(start);

--- a/src/test/java/tudelft/ti2806/pl3/data/wrapper/operation/unwrap/SpaceWrapperUnwrapTest.java
+++ b/src/test/java/tudelft/ti2806/pl3/data/wrapper/operation/unwrap/SpaceWrapperUnwrapTest.java
@@ -79,7 +79,7 @@ public class SpaceWrapperUnwrapTest {
 		space.getOutgoing().add(nodePosition4);
 		nodePosition4.getIncoming().add(space);
 		
-		HorizontalWrapper start = new HorizontalWrapper(horizontalList);
+		HorizontalWrapper start = new HorizontalWrapper(horizontalList, true);
 		
 		unwrap = new UnwrapTest();
 		unwrap.compute(start);

--- a/src/test/java/tudelft/ti2806/pl3/data/wrapper/operation/unwrap/SpaceWrapperWrappedUnwrapTest.java
+++ b/src/test/java/tudelft/ti2806/pl3/data/wrapper/operation/unwrap/SpaceWrapperWrappedUnwrapTest.java
@@ -81,7 +81,7 @@ public class SpaceWrapperWrappedUnwrapTest {
 		space.getIncoming().add(nodePosition0);
 		nodePosition4.getIncoming().add(space);
 		
-		HorizontalWrapper start = new HorizontalWrapper(horizontalList);
+		HorizontalWrapper start = new HorizontalWrapper(horizontalList, true);
 		
 		unwrap = new UnwrapTest();
 		unwrap.compute(start);

--- a/src/test/java/tudelft/ti2806/pl3/data/wrapper/operation/unwrap/VerticalWrappedUnwrapTest.java
+++ b/src/test/java/tudelft/ti2806/pl3/data/wrapper/operation/unwrap/VerticalWrappedUnwrapTest.java
@@ -69,7 +69,7 @@ public class VerticalWrappedUnwrapTest {
 		vertical.getIncoming().add(nodePosition1);
 		nodePosition4.getIncoming().add(vertical);
 		
-		HorizontalWrapper start = new HorizontalWrapper(horizontalList);
+		HorizontalWrapper start = new HorizontalWrapper(horizontalList, true);
 		
 		unwrap = new UnwrapTest();
 		unwrap.compute(start);

--- a/src/test/java/tudelft/ti2806/pl3/data/wrapper/util/NodeCombineUtilTest.java
+++ b/src/test/java/tudelft/ti2806/pl3/data/wrapper/util/NodeCombineUtilTest.java
@@ -30,11 +30,12 @@ public class NodeCombineUtilTest {
 	public void horizontalVerticalCollapseTest() throws IOException {
 		File nodesFile = new File("data/testdata/wrapTest.node.graph");
 		File edgesFile = new File("data/testdata/wrapTest.edge.graph");
-		GeneData geneData = GeneData.parseGenes("data/testdata/TestGeneAnnotationsFile");
-
+		GeneData geneData = GeneData
+				.parseGenes("data/testdata/TestGeneAnnotationsFile");
+		
 		GraphDataRepository gdr = new GraphDataRepository();
 		gdr.parseGraph(nodesFile, edgesFile, geneData);
-
+		
 		List<List<Wrapper>> list = HorizontalWrapUtil
 				.findCombineableNodes(new WrappedGraphData(gdr)
 						.getPositionedNodes());
@@ -71,25 +72,25 @@ public class NodeCombineUtilTest {
 	}
 	
 	@Test
-	public void combineNodesVerticalWithMultipleIncomming()
-			throws IOException {
+	public void combineNodesVerticalWithMultipleIncomming() throws IOException {
 		File nodesFile = new File("data/testdata/6TestCombineNodes.node.graph");
 		File edgesFile = new File("data/testdata/6TestCombineNodes.edge.graph");
-		GeneData geneData = GeneData.parseGenes("data/testdata/TestGeneAnnotationsFile");
+		GeneData geneData = GeneData
+				.parseGenes("data/testdata/TestGeneAnnotationsFile");
 		WrappedGraphData[] pgd = new WrappedGraphData[3];
-
+		
 		GraphDataRepository gdr = new GraphDataRepository();
-		gdr.parseGraph(nodesFile,edgesFile, geneData);
+		gdr.parseGraph(nodesFile, edgesFile, geneData);
 		pgd[0] = new WrappedGraphData(gdr);
 		
-		List<List<Wrapper>> list = VerticalWrapUtil
-				.findCombineableNodes(pgd[0].getPositionedNodes());
+		List<List<Wrapper>> list = VerticalWrapUtil.findCombineableNodes(pgd[0]
+				.getPositionedNodes());
 		Assert.assertEquals(list.size(), 3);
 		Assert.assertEquals(pgd[0].getPositionedNodes().size(), 6);
 		
 		pgd[1] = VerticalWrapUtil.collapseGraph(pgd[0]);
 		Assert.assertEquals(pgd[1].getPositionedNodes().size(), 3);
-		pgd[2] = HorizontalWrapUtil.collapseGraph(pgd[1]);
+		pgd[2] = HorizontalWrapUtil.collapseGraph(pgd[1], true);
 		Assert.assertEquals(pgd[2].getPositionedNodes().size(), 1);
 		
 		// WrapUtil collapse test
@@ -102,22 +103,23 @@ public class NodeCombineUtilTest {
 	public void spaceWrapUtilTest() throws IOException {
 		File nodesFile = new File("data/testdata/spaceWrapUtilTest.node.graph");
 		File edgesFile = new File("data/testdata/spaceWrapUtilTest.edge.graph");
-		GeneData geneData = GeneData.parseGenes("data/testdata/TestGeneAnnotationsFile");
-
+		GeneData geneData = GeneData
+				.parseGenes("data/testdata/TestGeneAnnotationsFile");
+		
 		GraphDataRepository gdr = new GraphDataRepository();
 		gdr.parseGraph(nodesFile, edgesFile, geneData);
 		WrappedGraphData original = new WrappedGraphData(gdr);
-
+		
 		Assert.assertEquals(original.getPositionedNodes().size(), 7);
 		Assert.assertNull(VerticalWrapUtil.collapseGraph(original));
-		Assert.assertNull(HorizontalWrapUtil.collapseGraph(original));
+		Assert.assertNull(HorizontalWrapUtil.collapseGraph(original, true));
 		List<List<Wrapper>> combineableNodes = SpaceWrapUtil
 				.findCombineableNodes(original.getPositionedNodes());
 		Assert.assertEquals(combineableNodes.size(), 1);
 		WrappedGraphData nwgd = SpaceWrapUtil.collapseGraph(original);
 		Assert.assertEquals(nwgd.getPositionedNodes().size(), 3);
 		Assert.assertNull(VerticalWrapUtil.collapseGraph(nwgd));
-		Assert.assertNull(HorizontalWrapUtil.collapseGraph(nwgd));
+		Assert.assertNull(HorizontalWrapUtil.collapseGraph(nwgd, true));
 		nwgd = SpaceWrapUtil.collapseGraph(nwgd);
 		Assert.assertEquals(nwgd.getPositionedNodes().size(), 1);
 	}
@@ -139,12 +141,13 @@ public class NodeCombineUtilTest {
 	public void nodeFixTest() throws IOException {
 		File nodesFile = new File("data/testdata/graphFixTest.node.graph");
 		File edgesFile = new File("data/testdata/graphFixTest.edge.graph");
-		GeneData geneData = GeneData.parseGenes("data/testdata/TestGeneAnnotationsFile");
-
+		GeneData geneData = GeneData
+				.parseGenes("data/testdata/TestGeneAnnotationsFile");
+		
 		GraphDataRepository gdr = new GraphDataRepository();
 		gdr.parseGraph(nodesFile, edgesFile, geneData);
 		WrappedGraphData original = new WrappedGraphData(gdr);
-
+		
 		Assert.assertNull(VerticalWrapUtil.collapseGraph(original));
 		Assert.assertNull(SpaceWrapUtil.collapseGraph(original));
 		Assert.assertEquals(1, original.getPositionedNodes().size(), 4);


### PR DESCRIPTION
Prevent low layer, the first horizontal layer, to unwrap.
After filtering, we don't want to see the long rows of single nodes connected in a horizontal wrapper, this branch fixes that.
This also causes the application to show just a single node when filtering on a single genome, which is hard to find, but this should be fixed by the "reset on center of the graph"-feature.