### PR TITLE
Fix/edge weight

### DIFF
--- a/src/main/java/tudelft/ti2806/pl3/data/filter/Filter.java
+++ b/src/main/java/tudelft/ti2806/pl3/data/filter/Filter.java
@@ -13,6 +13,8 @@ import java.util.List;
  *            the element type to filter
  */
 public interface Filter<T> {
-	
+
+	List<String> getGenomes();
+
 	void filter(List<T> list);
 }

--- a/src/main/java/tudelft/ti2806/pl3/data/filter/GenomeFilter.java
+++ b/src/main/java/tudelft/ti2806/pl3/data/filter/GenomeFilter.java
@@ -21,6 +21,11 @@ public class GenomeFilter implements Filter<DataNode> {
 		this.genomes = genomes;
 	}
 
+	@Override
+	public List<String> getGenomes() {
+		return genomes;
+	}
+
 	/**
 	 * Filter that removes all nodes that are not in the genome list.
 	 * It also removes the genomes from the node that should be filtered out.
@@ -43,5 +48,28 @@ public class GenomeFilter implements Filter<DataNode> {
 			}
 		}
 		nodes.removeAll(remove);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+
+		GenomeFilter that = (GenomeFilter) o;
+
+		if (genomes != null ? !genomes.equals(that.genomes) : that.genomes != null) {
+			return false;
+		}
+
+		return true;
+	}
+
+	@Override
+	public int hashCode() {
+		return genomes != null ? genomes.hashCode() : 0;
 	}
 }

--- a/src/main/java/tudelft/ti2806/pl3/util/CollectionUtil.java
+++ b/src/main/java/tudelft/ti2806/pl3/util/CollectionUtil.java
@@ -1,0 +1,45 @@
+package tudelft.ti2806.pl3.util;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Created by Boris Mattijssen on 17-06-15.
+ */
+public class CollectionUtil {
+
+	private CollectionUtil() {}
+
+
+	/**
+	 * Calculates the intersection between two collections.
+	 *
+	 * @param collection1
+	 * 		collection 1
+	 * @param collection2
+	 * 		collection 2
+	 * @param <T>
+	 * 		type of both collections
+	 * @return the intersection between the two collections
+	 */
+	public static <T> Collection<T> intersection(Collection<T> collection1, Collection<T> collection2) {
+		return collection1.stream().filter(t -> collection2.contains(t)).collect(Collectors.toList());
+	}
+
+	/**
+	 * Calculates the intersection between two collections.
+	 *
+	 * @param collection1
+	 * 		collection 1
+	 * @param collection2
+	 * 		collection 2
+	 * @param <T>
+	 * 		type of both collections
+	 * @return the intersection between the two collections
+	 */
+	public static <T> Set<T> intersectionListSet(List<T> collection1, Set<T> collection2) {
+		return collection1.stream().filter(t -> collection2.contains(t)).collect(Collectors.toSet());
+	}
+}

--- a/src/main/java/tudelft/ti2806/pl3/util/EdgeUtil.java
+++ b/src/main/java/tudelft/ti2806/pl3/util/EdgeUtil.java
@@ -120,33 +120,12 @@ public class EdgeUtil {
 			Set<Genome> genomes = new HashSet<>(wrapperClone.getGenome());
 			Collections.sort(wrapperClone.getOutgoing());
 			for (Wrapper outgoing : wrapperClone.getOutgoing()) {
-				Collection<Genome> intersection = intersection(outgoing.getGenome(), genomes);
+				Collection<Genome> intersection = CollectionUtil.intersection(
+						outgoing.getGenome(), genomes);
 				wrapperClone.getOutgoingWeight().add(intersection.size());
 				genomes.removeAll(intersection);
 			}
 		}
 	}
 
-	/**
-	 * Calculates the intersection between two collections.
-	 *
-	 * @param collection1
-	 * 		collection 1
-	 * @param collection2
-	 * 		collection 2
-	 * @param <T>
-	 * 		type of both collections
-	 * @return the intersection between the two collections
-	 */
-	public static <T> Collection<T> intersection(Collection<T> collection1, Collection<T> collection2) {
-		Collection<T> list = new ArrayList<T>();
-
-		for (T t : collection1) {
-			if (collection2.contains(t)) {
-				list.add(t);
-			}
-		}
-
-		return list;
-	}
 }

--- a/src/main/java/tudelft/ti2806/pl3/visualization/FilteredGraphModel.java
+++ b/src/main/java/tudelft/ti2806/pl3/visualization/FilteredGraphModel.java
@@ -2,8 +2,6 @@ package tudelft.ti2806.pl3.visualization;
 
 import tudelft.ti2806.pl3.ScreenSize;
 import tudelft.ti2806.pl3.data.Genome;
-import tudelft.ti2806.pl3.util.observable.LoadingObservable;
-import tudelft.ti2806.pl3.util.observers.LoadingObserver;
 import tudelft.ti2806.pl3.data.filter.Filter;
 import tudelft.ti2806.pl3.data.graph.DataNode;
 import tudelft.ti2806.pl3.data.graph.Edge;
@@ -16,12 +14,18 @@ import tudelft.ti2806.pl3.data.wrapper.operation.interest.ComputeInterest;
 import tudelft.ti2806.pl3.data.wrapper.operation.yposition.PositionNodeYOnGenomeSpace;
 import tudelft.ti2806.pl3.data.wrapper.util.WrapUtil;
 import tudelft.ti2806.pl3.util.CollectInterest;
+import tudelft.ti2806.pl3.util.CollectionUtil;
 import tudelft.ti2806.pl3.util.EdgeUtil;
+import tudelft.ti2806.pl3.util.observable.LoadingObservable;
+import tudelft.ti2806.pl3.util.observers.LoadingObserver;
 
 import java.util.ArrayList;
-import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Observable;
+import java.util.Set;
 
 /**
  * This model filters the original graph data, based on the filter selections.
@@ -40,7 +44,7 @@ public class FilteredGraphModel extends Observable implements LoadingObservable,
 
 	protected GraphDataRepository originalGraphData;
 	private Wrapper collapsedNode;
-	private Collection<Filter<DataNode>> filters;
+	private List<Filter<DataNode>> filters;
 	private PositionNodeYOnGenomeSpace positionNodeYOnGenomeSpace;
 
 	private ArrayList<LoadingObserver> loadingObservers = new ArrayList<>();
@@ -48,6 +52,8 @@ public class FilteredGraphModel extends Observable implements LoadingObservable,
 
 	private CollectInterest collectInterest;
 	private List<Genome> genomes;
+
+	private Map<List<Filter<DataNode>>, Integer> filtersToGenomesCountMap;
 
 	/**
 	 * Construct the model containing the filtered data.<br>
@@ -61,11 +67,12 @@ public class FilteredGraphModel extends Observable implements LoadingObservable,
 		this.originalGraphData = originalGraphData;
 		filters = new ArrayList<>();
 		genomes = new ArrayList<>();
+		filtersToGenomesCountMap = new HashMap<>();
 		positionNodeYOnGenomeSpace = new PositionNodeYOnGenomeSpace();
 		calculateCollapse = new CalculateCollapseOnSpace();
 	}
 
-	public void setFilters(Collection<Filter<DataNode>> filters) {
+	public void setFilters(List<Filter<DataNode>> filters) {
 		this.filters = filters;
 	}
 
@@ -185,5 +192,33 @@ public class FilteredGraphModel extends Observable implements LoadingObservable,
 
 	public List<Genome> getGenomes() {
 		return genomes;
+	}
+
+	/**
+	 * Count the genomes in the filtered data.
+	 * @return
+	 *      returns the amount of genomes in the original data set when no filters are applied,
+	 *      otherwise it calculates the amount of genomes in the filtered data and returns it.
+	 */
+	public int getGenomesCount() {
+		if (filters.size() > 0) {
+			if (filtersToGenomesCountMap.get(filters) == null) {
+				if (filters.size() == 1) {
+					filtersToGenomesCountMap.put(filters,
+							filters.iterator().next().getGenomes().size());
+				} else if (filters.size() > 1) {
+					Set<String> filteredGenomes = new HashSet<>(
+							filters.iterator().next().getGenomes());
+					for (Filter<DataNode> filter : filters) {
+						filteredGenomes = CollectionUtil.intersectionListSet(
+								filter.getGenomes(), filteredGenomes);
+					}
+					filtersToGenomesCountMap.put(filters, filteredGenomes.size());
+				}
+			}
+			return filtersToGenomesCountMap.get(filters);
+		} else {
+			return genomes.size();
+		}
 	}
 }

--- a/src/main/java/tudelft/ti2806/pl3/visualization/GraphController.java
+++ b/src/main/java/tudelft/ti2806/pl3/visualization/GraphController.java
@@ -100,7 +100,7 @@ public class GraphController implements Controller {
 	 */
 	public void addFilter(String name, Filter<DataNode> filter) {
 		filters.put(name, filter);
-		filteredGraphModel.setFilters(filters.values());
+		filteredGraphModel.setFilters(new ArrayList<>(filters.values()));
 		filteredGraphModel.produceWrappedGraphData();
 		graphMoved();
 	}

--- a/src/main/java/tudelft/ti2806/pl3/visualization/GraphView.java
+++ b/src/main/java/tudelft/ti2806/pl3/visualization/GraphView.java
@@ -169,7 +169,8 @@ public class GraphView
 		Edge edge = graph.addEdge(from.getId() + "-" + to.getId(),
 				Integer.toString(from.getId()), Integer.toString(to.getId()), true);
 		int weight = from.getOutgoingWeight().get(i);
-		float percent = ((float) weight) / ((float) zoomedGraphModel.getGenomes().size());
+		float percent = ((float) weight) / ((float) zoomedGraphModel.getGenomesCount());
+//		System.out.println(zoomedGraphModel.getGenomesCount());
 		if (weight == 0) {
 			edge.addAttribute("ui.label", "fix me!");
 			throw new EdgeZeroWeightException(

--- a/src/main/java/tudelft/ti2806/pl3/visualization/GraphView.java
+++ b/src/main/java/tudelft/ti2806/pl3/visualization/GraphView.java
@@ -173,7 +173,7 @@ public class GraphView
 				Integer.toString(from.getId()), Integer.toString(to.getId()), true);
 		int weight = from.getOutgoingWeight().get(i);
 		float percent = ((float) weight) / ((float) zoomedGraphModel.getGenomesCount());
-//		System.out.println(zoomedGraphModel.getGenomesCount());
+
 		if (weight == 0) {
 			edge.addAttribute("ui.label", "fix me!");
 			throw new EdgeZeroWeightException(

--- a/src/main/java/tudelft/ti2806/pl3/visualization/GraphView.java
+++ b/src/main/java/tudelft/ti2806/pl3/visualization/GraphView.java
@@ -8,15 +8,16 @@ import org.graphstream.ui.geom.Point3;
 import org.graphstream.ui.swingViewer.View;
 import org.graphstream.ui.swingViewer.Viewer;
 import org.graphstream.ui.swingViewer.util.DefaultShortcutManager;
-import tudelft.ti2806.pl3.util.observable.LoadingObservable;
-import tudelft.ti2806.pl3.util.observers.LoadingObserver;
-import tudelft.ti2806.pl3.controls.MouseManager;
+
 import tudelft.ti2806.pl3.ScreenSize;
+import tudelft.ti2806.pl3.controls.MouseManager;
 import tudelft.ti2806.pl3.data.graph.DataNode;
 import tudelft.ti2806.pl3.data.wrapper.Wrapper;
 import tudelft.ti2806.pl3.data.wrapper.WrapperClone;
 import tudelft.ti2806.pl3.exception.EdgeZeroWeightException;
 import tudelft.ti2806.pl3.exception.NodeNotFoundException;
+import tudelft.ti2806.pl3.util.observable.LoadingObservable;
+import tudelft.ti2806.pl3.util.observers.LoadingObserver;
 
 import java.awt.Component;
 import java.awt.event.ComponentAdapter;
@@ -36,7 +37,9 @@ import java.util.Observer;
  */
 public class GraphView
 		implements Observer, tudelft.ti2806.pl3.View, ViewInterface, LoadingObservable {
-	/**
+	private static final float EDGE_THICKNESS_SCALE = 10f;
+
+    /**
 	 * The zoomLevel used to draw the graph.<br>
 	 * A zoom level of 1.0 shows the graph 1:1, so that every base pair should
 	 * be readable, each with  pixels to draw its
@@ -125,7 +128,7 @@ public class GraphView
 		graph.clear();
 		setGraphPropertys();
 		final double someSize = panel.getBounds().height
-				/ ((double) panel.getBounds().width * zoomLevel / zoomedGraphModel
+				/ (panel.getBounds().width * zoomLevel / zoomedGraphModel
 				.getWrappedCollapsedNode().getWidth())
 				/ zoomedGraphModel.getWrappedCollapsedNode().getGenome().size();
 		graphData.forEach(node -> {
@@ -176,7 +179,7 @@ public class GraphView
 			throw new EdgeZeroWeightException(
 					"The weight of the edge from " + from + " to " + to + " cannot be 0.");
 		} else {
-			edge.addAttribute("ui.style", "size: " + (percent * 5f) + "px;");
+			edge.addAttribute("ui.style", "size: " + (percent * EDGE_THICKNESS_SCALE) + "px;");
 		}
 	}
 	
@@ -227,7 +230,7 @@ public class GraphView
 	 */
 	public void setOffsetToCenter() {
 		Point3 point3 = viewer.getDefaultView().getCamera()
-				.transformPxToGu(0, (double) ScreenSize.getInstance().getHeight() / 2d);
+				.transformPxToGu(0, ScreenSize.getInstance().getHeight() / 2d);
 		offsetToCenter = (float) point3.x * -1;
 	}
 

--- a/src/main/java/tudelft/ti2806/pl3/visualization/ZoomedGraphModel.java
+++ b/src/main/java/tudelft/ti2806/pl3/visualization/ZoomedGraphModel.java
@@ -142,4 +142,8 @@ public class ZoomedGraphModel extends Observable implements Observer,
 			loadingObserver.update(this, arguments);
 		}
 	}
+
+	public int getGenomesCount() {
+		return filteredGraphModel.getGenomesCount();
+	}
 }


### PR DESCRIPTION
Fixes the scale of the edge weight after filtering.
Before the fix, it would still scale to the total amount of genomes in the data set instead of the total amount of genomes currently in the filtered data.