### PR TITLE
Added upper limit to zoom level 

### DIFF
--- a/src/main/java/tudelft/ti2806/pl3/ScreenSize.java
+++ b/src/main/java/tudelft/ti2806/pl3/ScreenSize.java
@@ -77,7 +77,7 @@ public class ScreenSize {
 	 * Calculate the sizes of the windows.
 	 */
 	public void calculate() {
-		zoomBarHeight = calculate(ZoomBarView.ZOOMBAR_FACTOR, getHeight());
+		zoomBarHeight = calculate(ZoomBarView.ZOOM_BAR_FACTOR, getHeight());
 		sideBarWidth = calculate(SideBarView.SIDEBAR_FACTOR, getWidth());
 	}
 	

--- a/src/main/java/tudelft/ti2806/pl3/visualization/ZoomedGraphModel.java
+++ b/src/main/java/tudelft/ti2806/pl3/visualization/ZoomedGraphModel.java
@@ -37,6 +37,8 @@ public class ZoomedGraphModel extends Observable implements Observer, LoadingObs
 	 * Minimum distance between nodes in pixels, can be overruled by {@link #MIN_NODE_COUNT}.
 	 */
 	private static final float MIN_NODE_DISTANCE = 60f;
+	private static final float MIN_ZOOM_LEVEL = 1;
+	private static final float MAX_ZOOM_LEVEL = 1000;
 	private FilteredGraphModel filteredGraphModel;
 
 	private Wrapper collapsedNode;
@@ -67,8 +69,12 @@ public class ZoomedGraphModel extends Observable implements Observer, LoadingObs
 	 *            the new zoom level
 	 */
 	public void setZoomLevel(float zoomLevel) {
-		if (zoomLevel >= 1) {
-			this.zoomLevel = zoomLevel;
+		this.zoomLevel = zoomLevel;
+		if (zoomLevel < MIN_ZOOM_LEVEL) {
+			this.zoomLevel = MIN_ZOOM_LEVEL;
+		}
+		if (zoomLevel > MAX_ZOOM_LEVEL) {
+			this.zoomLevel = MAX_ZOOM_LEVEL;
 		}
 	}
 	

--- a/src/main/java/tudelft/ti2806/pl3/zoombar/ZoomBarView.java
+++ b/src/main/java/tudelft/ti2806/pl3/zoombar/ZoomBarView.java
@@ -80,7 +80,10 @@ public class ZoomBarView extends JPanel implements View, Observer {
 	 * 		graphics
 	 */
 	private void drawIndicator(Graphics g) {
-		if (width > 0) {
+		if (width != -1) {
+			if (width < 5) {
+				width = 5;
+			}
 			Graphics2D g2 = (Graphics2D) g;
 			float thickness = 2;
 			Stroke oldStroke = g2.getStroke();

--- a/src/main/java/tudelft/ti2806/pl3/zoombar/ZoomBarView.java
+++ b/src/main/java/tudelft/ti2806/pl3/zoombar/ZoomBarView.java
@@ -21,7 +21,8 @@ import javax.swing.JPanel;
  */
 @SuppressWarnings("serial")
 public class ZoomBarView extends JPanel implements View, Observer {
-	public static final double ZOOMBAR_FACTOR = 0.1;
+	public static final double ZOOM_BAR_FACTOR = 0.1;
+	private static final int INDICATOR_MIN_WIDTH = 5;
 
 	private int x = 0;
 	private int width = -1;
@@ -81,8 +82,8 @@ public class ZoomBarView extends JPanel implements View, Observer {
 	 */
 	private void drawIndicator(Graphics g) {
 		if (width != -1) {
-			if (width < 5) {
-				width = 5;
+			if (width < INDICATOR_MIN_WIDTH) {
+				width = INDICATOR_MIN_WIDTH;
 			}
 			Graphics2D g2 = (Graphics2D) g;
 			float thickness = 2;

--- a/src/test/java/tudelft/ti2806/pl3/ScreensizeTest.java
+++ b/src/test/java/tudelft/ti2806/pl3/ScreensizeTest.java
@@ -36,7 +36,7 @@ public class ScreensizeTest {
 	public void testCalculateZoombar() {
 		screenSize.setHeight(testHeight);
 		screenSize.calculate();
-		int zoombarheight = (int) (ZoomBarView.ZOOMBAR_FACTOR * testHeight);
+		int zoombarheight = (int) (ZoomBarView.ZOOM_BAR_FACTOR * testHeight);
 		assertEquals(zoombarheight, screenSize.getZoomBarHeight());
 
 	}

--- a/src/test/java/tudelft/ti2806/pl3/visualisation/ZoomedGraphModelTest.java
+++ b/src/test/java/tudelft/ti2806/pl3/visualisation/ZoomedGraphModelTest.java
@@ -34,6 +34,8 @@ public class ZoomedGraphModelTest {
 		zoomedGraphModel.setZoomLevel(5);
 		assertEquals(5, zoomedGraphModel.getZoomLevel(), 0);
 		zoomedGraphModel.setZoomLevel(-1);
-		assertEquals(5, zoomedGraphModel.getZoomLevel(), 0);
+		assertEquals(1, zoomedGraphModel.getZoomLevel(), 0);
+		zoomedGraphModel.setZoomLevel(1001);
+		assertEquals(1000, zoomedGraphModel.getZoomLevel(), 0);
 	}
 }


### PR DESCRIPTION
Added upper limit to zoom level and lower limit on zoom bar indicator width.
From the interaction design survey I realized that it is too easy to zoom too far in when using a trackpad. That's why I've put an upper limit on the zoom level.
Also I've put a lower limit on the zoom bar indicator width, such that it is always visible.